### PR TITLE
fix: detect filetype ignoring case

### DIFF
--- a/src-tauri/src/file_handler.rs
+++ b/src-tauri/src/file_handler.rs
@@ -63,7 +63,7 @@ pub enum FileType {
 
 pub fn determine_file_type(path: &Path) -> FileType {
     let extension = path.extension().and_then(|s| s.to_str()).unwrap_or("");
-    match extension {
+    match extension.to_lowercase().as_str() {
         "jpg" | "jpeg" => FileType::Image("image/jpeg".to_string()),
         "png" => FileType::Image("image/png".to_string()),
         "pdf" => FileType::Pdf,


### PR DESCRIPTION
in the current code, file extension is directly compared to a list of known values given in lower case (eg `jpg`, `pdf`). this creates the situation where `.PDF` is not recognized properly as pdf files. this PR fixes that.