### PR TITLE
Fixes

### DIFF
--- a/src-tauri/src/interaction.rs
+++ b/src-tauri/src/interaction.rs
@@ -107,11 +107,11 @@ impl Interaction {
                 tool_calls,
                 ..
             } => {
-                !content.iter().any(|c| !c.is_empty())
-                    || tool_calls.as_ref().is_some_and(|calls| !calls.is_empty())
+                content.iter().all(|c| c.is_empty())
+                    && tool_calls.as_ref().is_none_or(|c| c.is_empty())
             }
             Interaction::ToolResult { .. } => false,
-            Interaction::UserMessage { content, .. } => !content.iter().any(|c| !c.is_empty()),
+            Interaction::UserMessage { content, .. } => content.iter().all(|c| c.is_empty()),
         }
     }
 }

--- a/src-tauri/src/interaction.rs
+++ b/src-tauri/src/interaction.rs
@@ -152,26 +152,31 @@ impl History {
         }
     }
 
-    pub fn delete_by_tool_id(&mut self, tool_call_id_to_delete: &str) {
-        // Remove the ToolResult with the given tool_call_id
-        self.inner.retain(|interaction| {
-            if let Interaction::ToolResult { tool_call_id, .. } = interaction {
-                tool_call_id != tool_call_id_to_delete
-            } else {
-                true
-            }
-        });
+    pub fn delete_by_tool_id(&mut self, llm_interaction_id: usize, tool_call_id_to_delete: &str) {
+        let llm_interaction_index = self.inner.iter().position(|i| i.id() == llm_interaction_id);
 
-        // Find any LlmResponse and remove the matching tool_call from it
-        for interaction in self.inner.iter_mut() {
-            if let Interaction::LlmResponse { tool_calls, .. } = interaction
+        if let Some(index) = llm_interaction_index {
+            // Remove the matching tool call from the LlmResponse
+            if let Some(interaction) = self.inner.get_mut(index)
+                && let Interaction::LlmResponse { tool_calls, .. } = interaction
                 && let Some(calls) = tool_calls
             {
                 calls.retain(|call| call.id != tool_call_id_to_delete);
             }
+
+            // Find and remove the corresponding ToolResult that appears after the LlmResponse
+            if let Some(tool_result_index) = self.inner.iter().skip(index).position(|i| {
+                if let Interaction::ToolResult { tool_call_id, .. } = i {
+                    tool_call_id == tool_call_id_to_delete
+                } else {
+                    false
+                }
+            }) {
+                self.inner.remove(index + tool_result_index);
+            }
         }
 
-        // Finally prune LLM messages that became empty
+        // Finally, prune any LLM messages that have become empty
         self.inner.retain(|interaction| !interaction.is_empty());
     }
 
@@ -182,14 +187,28 @@ impl History {
             match interaction {
                 Interaction::LlmResponse {
                     tool_calls: Some(calls),
+                    interaction_id,
                     ..
                 } => {
                     for call in calls {
-                        self.delete_by_tool_id(&call.id);
+                        self.delete_by_tool_id(interaction_id, &call.id);
                     }
                 }
                 Interaction::ToolResult { tool_call_id, .. } => {
-                    self.delete_by_tool_id(&tool_call_id);
+                    // find the corrosponding llm response
+                    if let Some(llm_interaction) = self.inner.iter().find(|i| {
+                        if let Interaction::LlmResponse {
+                            tool_calls: Some(calls),
+                            ..
+                        } = i
+                        {
+                            calls.iter().any(|c| c.id == tool_call_id)
+                        } else {
+                            false
+                        }
+                    }) {
+                        self.delete_by_tool_id(llm_interaction.id(), &tool_call_id);
+                    }
                 }
                 _ => {}
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,9 +125,17 @@ fn delete_message(id: usize, state: AppState<'_>) -> Result<()> {
 }
 
 #[tauri::command]
-fn delete_tool_interaction(tool_call_id: String, state: AppState<'_>) -> Result<()> {
+fn delete_tool_interaction(
+    llm_interaction_id: usize,
+    tool_call_id: String,
+    state: AppState<'_>,
+) -> Result<()> {
     cancel_outstanding_request(state.clone())?;
-    state.history.lock().unwrap().delete_by_tool_id(&tool_call_id);
+    state
+        .history
+        .lock()
+        .unwrap()
+        .delete_by_tool_id(llm_interaction_id, &tool_call_id);
     Ok(())
 }
 
@@ -155,7 +163,7 @@ pub fn run() {
             cancel_outstanding_request,
             ensure_libreoffice,
             delete_message,
-            delete_tool_interaction
+            delete_tool_interaction,
         ])
         .setup(|app| {
             STORE.get_or_init(|| {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,7 +85,8 @@ function App() {
           break;
         case "ToolCall":
           setMessages((prev) => {
-            if (prev.some((m) => m.id === update.id)) return prev;
+            if (prev.some((m) => m.tool_call_id === update.tool_call_id))
+              return prev;
             return [
               ...prev,
               {
@@ -301,7 +302,7 @@ function App() {
           .sort((a, b) => a.id - b.id)
           .map((m) => (
             <ChatBubble
-              key={m.id}
+              key={m.tool_call_id || m.id}
               {...m}
               onCopy={() => handleCopy(m.content)}
               onDelete={() => handleDelete(m.id)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,7 +85,12 @@ function App() {
           break;
         case "ToolCall":
           setMessages((prev) => {
-            if (prev.some((m) => m.tool_call_id === update.tool_call_id))
+            if (
+              prev.some(
+                (m) =>
+                  m.id === update.id && m.tool_call_id === update.tool_call_id
+              )
+            )
               return prev;
             return [
               ...prev,
@@ -245,11 +250,14 @@ function App() {
     delete_message(id);
   };
 
-  const handleDeleteTool = (tool_call_id: string) => {
+  const handleDeleteTool = (llm_interaction_id: number, tool_call_id: string) => {
     setMessages((prev) =>
-      prev.filter((m) => m.tool_call_id !== tool_call_id)
+      prev.filter(
+        (m) =>
+          !(m.id === llm_interaction_id && m.tool_call_id === tool_call_id)
+      )
     );
-    delete_tool_interaction(tool_call_id);
+    delete_tool_interaction(llm_interaction_id, tool_call_id);
   };
 
   const handleCancel = () => {
@@ -306,7 +314,9 @@ function App() {
               {...m}
               onCopy={() => handleCopy(m.content)}
               onDelete={() => handleDelete(m.id)}
-              onDeleteTool={handleDeleteTool}
+              onDeleteTool={(llm_interaction_id, tool_call_id) =>
+                handleDeleteTool(llm_interaction_id, tool_call_id)
+              }
             />
           ))}
         {isTyping && (

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,8 +29,8 @@ export const delete_message = async (id: number): Promise<void> => {
 	await invoke("delete_message", { id });
 }
 
-export const delete_tool_interaction = async (tool_call_id: string): Promise<void> => {
-	await invoke("delete_tool_interaction", { toolCallId: tool_call_id });
+export const delete_tool_interaction = async (llm_interaction_id: number, tool_call_id: string): Promise<void> => {
+	await invoke("delete_tool_interaction", { llmInteractionId: llm_interaction_id, toolCallId: tool_call_id });
 }
 
 export const onLibreofficeUpdate = async (

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -91,10 +91,11 @@ export const ChatBubble = ({
   tool_call_id,
   toolArgs,
   toolResult,
+  id,
 }: IChatCompletionMessage & {
   onCopy?: () => void;
   onDelete?: () => void;
-  onDeleteTool?: (tool_call_id: string) => void;
+  onDeleteTool?: (llm_interaction_id: number, tool_call_id: string) => void;
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -155,7 +156,7 @@ export const ChatBubble = ({
           </button>
           {isTool ? (
             <button
-              onClick={() => onDeleteTool?.(tool_call_id!)}
+              onClick={() => onDeleteTool?.(id, tool_call_id!)}
               title="Delete Tool Interaction"
             >
               <FaTrash />


### PR DESCRIPTION
This pull request refactors the handling of tool interactions and LLM responses in both the backend (`src-tauri`) and frontend (`src`). The changes enhance the logic for deleting tool interactions by associating them with their parent LLM interactions, ensuring consistency and preventing orphaned data. Additionally, the frontend now uses stricter checks for identifying and managing tool interactions.

### Backend Changes (`src-tauri`):

* **Enhanced Tool Interaction Deletion Logic:**
  - Updated the `delete_by_tool_id` method in `History` to require the parent LLM interaction ID and ensure both the tool result and its associated LLM response are cleaned up properly.
  - Adjusted the `delete_message` and `delete_tool_interaction` functions to reflect the new method signature, requiring the LLM interaction ID for tool deletions. 
* **Improved Empty Interaction Pruning:**
  - Refactored the `is_empty` logic in the `Interaction` enum to simplify checks for empty content and tool calls.

* **Recursive Deletion Updates:**
  - Modified recursive deletion logic to locate the corresponding LLM response before deleting a tool result, ensuring proper linkage.

### Frontend Changes (`src`):

* **Stricter Tool Interaction Identification:**
  - Updated the `App` component to use both `id` and `tool_call_id` for identifying tool interactions, preventing duplicate entries.
  - Refined the `handleDeleteTool` function to filter messages based on both LLM interaction ID and tool call ID.

* **Component and Command Updates:**
  - Updated the `ChatBubble` component to pass both `id` and `tool_call_id` for deletion callbacks, ensuring accurate deletions. 
  - Adjusted the `delete_tool_interaction` command to accept and pass the LLM interaction ID to the backend.