### PR TITLE
fix: fine tune path handling

### DIFF
--- a/src-tauri/src/tools/find.rs
+++ b/src-tauri/src/tools/find.rs
@@ -76,12 +76,11 @@ pub fn find_internal(root_dir: &str, glob_pattern: &str, limit: usize) -> Result
     let result: Vec<String> = entries
         .iter()
         .map(|entry| {
-            entry
-                .to_str()
-                .unwrap_or_default()
-                .strip_prefix(root_dir)
-                .unwrap_or_default()
-                .to_string()
+            if let Ok(relative) = entry.strip_prefix(root_dir) {
+                relative.to_str().unwrap_or_default().to_string()
+            } else {
+                String::new()
+            }
         })
         .collect();
 

--- a/src-tauri/src/tools/ls.rs
+++ b/src-tauri/src/tools/ls.rs
@@ -1,6 +1,6 @@
+use crate::Result;
 use crate::error::Error;
 use crate::utils::jailed::Jailed;
-use crate::{Result};
 use std::path::Path;
 
 use super::{Function, Tool};
@@ -51,7 +51,15 @@ pub async fn ls(args: LsArgs) -> Result<Vec<String>> {
         Ok(entries) => {
             let result: Vec<String> = entries
                 .flatten()
-                .map(|entry| entry.file_name().to_string_lossy().to_string())
+                .map(|entry| {
+                    let mut name = entry.file_name().to_string_lossy().to_string();
+                    if let Ok(file_meta) = entry.metadata()
+                        && file_meta.is_dir()
+                    {
+                        name.push('/');
+                    }
+                    name
+                })
                 .collect();
             Ok(result)
         }


### PR DESCRIPTION
- make `ls` add suffix '/' for directories.
- make `find` return results without leading path separator (eg / or \)