### PR TITLE
fix: streamline keyboard shortcut handling for clearing all

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,10 +175,8 @@ function App() {
       if (e.ctrlKey) {
         switch (e.key) {
           case "k":
-            if (e.shiftKey) {
-              e.preventDefault();
-              handleClearAll();
-            }
+            e.preventDefault();
+            handleClearAll();
             break;
           case "o":
             e.preventDefault();


### PR DESCRIPTION
This pull request makes a minor change to the `src/App.tsx` file, specifically in the `App` component. The change removes the conditional check for `e.shiftKey` when handling the "Ctrl+K" keyboard shortcut, simplifying the logic for clearing all items.